### PR TITLE
Add dual-scale renderer with floating origin support

### DIFF
--- a/src/components/Asteroids/AsteroidField.tsx
+++ b/src/components/Asteroids/AsteroidField.tsx
@@ -3,7 +3,10 @@ import { Asteroid01, Instances } from "../models/asteroids/01/Asteroid01";
 import { Euler, Vector3 } from "three";
 import random from "@/helpers/random";
 
-const fieldPosition = new Vector3(0, 0, 400);
+import SimGroup from "@/components/space/SimGroup";
+import { Vector3Like } from "@/sim/units";
+
+const fieldPositionKm: Vector3Like = [0, 0, 400];
 
 const AsteroidField = () => {
   const rng = random(12344);
@@ -27,22 +30,24 @@ const AsteroidField = () => {
   }, []);
 
   return (
-    <Instances position={fieldPosition} frustumCulled={false}>
-      {positions.map((pos, i) => {
-        return (
-          <Asteroid01
-            key={i}
-            position={
-              new Vector3(pos[0] * scale, pos[1] * scale, pos[2] * scale)
-            }
-            scale={rng.nextFloat() * 10}
-            rotation={
-              new Euler(rng.nextFloat(), rng.nextFloat(), rng.nextFloat())
-            }
-          />
-        );
-      })}
-    </Instances>
+    <SimGroup space="local" positionKm={fieldPositionKm}>
+      <Instances frustumCulled={false}>
+        {positions.map((pos, i) => {
+          return (
+            <Asteroid01
+              key={i}
+              position={
+                new Vector3(pos[0] * scale, pos[1] * scale, pos[2] * scale)
+              }
+              scale={rng.nextFloat() * 10}
+              rotation={
+                new Euler(rng.nextFloat(), rng.nextFloat(), rng.nextFloat())
+              }
+            />
+          );
+        })}
+      </Instances>
+    </SimGroup>
   );
 };
 

--- a/src/components/Spaceship.tsx
+++ b/src/components/Spaceship.tsx
@@ -1,14 +1,14 @@
 import { logLimit } from "@/helpers/math";
 import { useFrame } from "@react-three/fiber";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Quaternion, Vector3, Mesh, MathUtils } from "three";
 import { ShipOne } from "./models/ships/ShipOne";
 import { lerp } from "three/src/math/MathUtils.js";
 import { useAtomValue, useSetAtom } from "jotai";
 import { hudInfoAtom, movementAtom } from "@/store/store";
+import { useMaybeRecenterOrigin, useWorldOriginKm } from "@/sim/worldOrigin";
 
 const quaternion = new Quaternion();
-const zeroVector = new Vector3(0, 0, 0);
 const xAxis = new Vector3(1, 0, 0);
 const yAxis = new Vector3(0, 1, 0);
 const direction = new Vector3(0, 0, 1); // This is the forward direction in the spaceship's local space
@@ -26,16 +26,25 @@ const hudUpdateInterval = 0.25;
 const SpaceShip = () => {
   const movement = useAtomValue(movementAtom);
   const setHudInfo = useSetAtom(hudInfoAtom);
+  const worldOrigin = useWorldOriginKm();
+  const maybeRecenter = useMaybeRecenterOrigin();
   const shipRef = useRef<Mesh>(null!);
   const modelRef = useRef<Mesh>(null!);
-  const velocity = useRef(zeroVector);
+  const velocity = useRef(new Vector3());
+  const simPositionKm = useRef(new Vector3());
+  const relativePosition = useRef(new Vector3());
+  const originVec = useRef(new Vector3());
+  const oldSimPosition = useRef(new Vector3());
 
   const movementYaw = useRef(0); // Current roll
   const movementPitch = useRef(0); // Current yaw
   const visualRoll = useRef(0); // Current visual roll
   const visualPitch = useRef(0); // Current visual pitch
   const currentSpeed = useRef(0);
-  const oldPosition = useRef(zeroVector);
+
+  useEffect(() => {
+    originVec.current.set(worldOrigin[0], worldOrigin[1], worldOrigin[2]);
+  }, [worldOrigin]);
 
   useFrame(({ camera }, delta) => {
     if (shipRef.current && modelRef.current) {
@@ -104,19 +113,24 @@ const SpaceShip = () => {
         shipSpeed * currentSpeed.current * delta
       );
 
-      // Update spaceship position based on velocity and delta time
-      shipRef.current.position.add(velocity.current);
+      // Update simulation position based on velocity and delta time (km)
+      simPositionKm.current.add(velocity.current);
 
       timeAccumulator += delta;
       if (timeAccumulator > hudUpdateInterval) {
         setHudInfo({
           speed:
-            shipRef.current.position.distanceTo(oldPosition.current) /
+            simPositionKm.current.distanceTo(oldSimPosition.current) /
             hudUpdateInterval,
         });
         timeAccumulator = 0;
-        oldPosition.current.copy(shipRef.current.position);
+        oldSimPosition.current.copy(simPositionKm.current);
       }
+
+      relativePosition.current
+        .copy(simPositionKm.current)
+        .sub(originVec.current);
+      shipRef.current.position.copy(relativePosition.current);
 
       // Calculate the camera's position
       offsetVector
@@ -134,12 +148,15 @@ const SpaceShip = () => {
       camera.quaternion
         .copy(shipRef.current.quaternion)
         .multiply(rotationQuaternion);
+
+      maybeRecenter(simPositionKm.current);
     }
   });
 
   return (
     <mesh ref={shipRef}>
       <mesh ref={modelRef}>
+        {/* TODO: rescale ship model to canonical km units when asset scale is defined. */}
         <ShipOne />
       </mesh>
     </mesh>

--- a/src/components/Star/Star.tsx
+++ b/src/components/Star/Star.tsx
@@ -1,43 +1,35 @@
 /* eslint-disable jsx-a11y/alt-text */
 import { Billboard, Image, Sphere } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
-import { useRef } from "react";
-import { FrontSide, Mesh, Vector3 } from "three";
+import { FrontSide } from "three";
 
-const position = new Vector3(65_000, 0, 130_000);
+import SimGroup from "@/components/space/SimGroup";
+import { SCALED_UNITS_PER_KM, Vector3Like } from "@/sim/units";
+
+const STAR_POSITION_KM: Vector3Like = [65_000_000, 0, 130_000_000];
+const RADIUS_KM = 696_340;
 
 type StarProps = {
   bloom: boolean;
+  positionKm?: Vector3Like;
 };
 
-const RADIUS = 696.34;
-
-const Star = ({ bloom }: StarProps) => {
-  const star = useRef<Mesh>(null!);
-
-  // move star with camera to avoid unhandled colission issues
-  useFrame(({ camera }) => {
-    if (star.current) {
-      star.current.position.copy(camera.position).add(position);
-    }
-  });
-
+const Star = ({ bloom, positionKm = STAR_POSITION_KM }: StarProps) => {
   return (
-    <>
+    <SimGroup space="scaled" positionKm={positionKm}>
       <directionalLight // Star
-        position={position}
+        position={[0, 0, 0]}
         intensity={10}
         color="white"
         castShadow
-        scale={RADIUS}
+        scale={RADIUS_KM * SCALED_UNITS_PER_KM}
       />
-      <mesh ref={star} position={position}>
+      <mesh>
         {!bloom && (
           <Billboard>
             <Image url="/assets/star.png" scale={2048} transparent />
           </Billboard>
         )}
-        <Sphere args={[RADIUS, 16, 16]}>
+        <Sphere args={[RADIUS_KM * SCALED_UNITS_PER_KM, 16, 16]}>
           <meshBasicMaterial
             color={[512, 512, 512]}
             toneMapped={false}
@@ -46,7 +38,7 @@ const Star = ({ bloom }: StarProps) => {
           />
         </Sphere>
       </mesh>
-    </>
+    </SimGroup>
   );
 };
 

--- a/src/components/Stars/StarsComponent.tsx
+++ b/src/components/Stars/StarsComponent.tsx
@@ -8,6 +8,8 @@ import {
   Material,
 } from "three";
 
+import { SCALED_UNITS_PER_KM } from "@/sim/units";
+
 const StarsComponent = () => {
   const stars = useRef<
     Points<BufferGeometry<NormalBufferAttributes>, Material | Material[]>
@@ -15,7 +17,9 @@ const StarsComponent = () => {
 
   useFrame(({ camera }) => {
     if (stars.current) {
-      stars.current.position.copy(camera.position);
+      stars.current.position
+        .copy(camera.position)
+        .multiplyScalar(SCALED_UNITS_PER_KM);
     }
   });
 

--- a/src/components/space/SimGroup.tsx
+++ b/src/components/space/SimGroup.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Group, Vector3 } from "three";
+
+import { Vector3Like, asVector3, toLocalUnitsKm, toScaledUnitsKm } from "@/sim/units";
+import { useWorldOriginKm } from "@/sim/worldOrigin";
+
+export type SimGroupProps = {
+  space: "local" | "scaled";
+  positionKm: Vector3Like;
+  children?: React.ReactNode;
+};
+
+const SimGroup = ({ space, positionKm, children }: SimGroupProps) => {
+  const groupRef = useRef<Group>(null!);
+  const originVec = useRef(new Vector3());
+  const positionVec = useRef(new Vector3());
+  const relativeKm = useRef(new Vector3());
+  const worldUnits = useRef(new Vector3());
+  const worldOrigin = useWorldOriginKm();
+
+  useEffect(() => {
+    asVector3(positionKm, positionVec.current);
+  }, [positionKm]);
+
+  useEffect(() => {
+    originVec.current.set(worldOrigin[0], worldOrigin[1], worldOrigin[2]);
+    relativeKm.current.copy(positionVec.current).sub(originVec.current);
+
+    if (space === "local") {
+      toLocalUnitsKm(relativeKm.current, worldUnits.current);
+    } else {
+      toScaledUnitsKm(relativeKm.current, worldUnits.current);
+    }
+
+    if (groupRef.current) {
+      groupRef.current.position.copy(worldUnits.current);
+    }
+  }, [positionKm, space, worldOrigin]);
+
+  return <group ref={groupRef}>{children}</group>;
+};
+
+export default SimGroup;

--- a/src/components/space/SpaceRenderer.tsx
+++ b/src/components/space/SpaceRenderer.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { createPortal, useFrame, useThree } from "@react-three/fiber";
+import { ComponentProps, ReactNode, useEffect, useMemo } from "react";
+import { EffectComposer } from "@react-three/postprocessing";
+import * as THREE from "three";
+
+import { SCALED_UNITS_PER_KM } from "@/sim/units";
+
+export const LOCAL_CAMERA_NEAR = 0.01;
+export const LOCAL_CAMERA_FAR = 20_000;
+export const SCALED_CAMERA_NEAR = 0.001;
+export const SCALED_CAMERA_FAR = 2_000_000;
+
+type SpaceRendererProps = {
+  scaled?: ReactNode;
+  local?: ReactNode;
+  localEffects?: ReactNode;
+  composerProps?: Omit<
+    ComponentProps<typeof EffectComposer>,
+    "children" | "scene" | "camera"
+  >;
+};
+
+const SpaceRenderer = ({
+  scaled,
+  local,
+  localEffects,
+  composerProps,
+}: SpaceRendererProps) => {
+  const scaledScene = useMemo(() => new THREE.Scene(), []);
+  const localScene = useMemo(() => new THREE.Scene(), []);
+  const scaledCamera = useMemo(() => new THREE.PerspectiveCamera(), []);
+
+  const { camera: localCamera, gl, size } = useThree();
+
+  useEffect(() => {
+    localCamera.near = LOCAL_CAMERA_NEAR;
+    localCamera.far = LOCAL_CAMERA_FAR;
+    localCamera.updateProjectionMatrix();
+  }, [localCamera]);
+
+  useEffect(() => {
+    scaledCamera.near = SCALED_CAMERA_NEAR;
+    scaledCamera.far = SCALED_CAMERA_FAR;
+    scaledCamera.updateProjectionMatrix();
+  }, [scaledCamera]);
+
+  useEffect(() => {
+    scaledCamera.aspect = size.width / size.height;
+    scaledCamera.fov = (localCamera as THREE.PerspectiveCamera).fov;
+    scaledCamera.updateProjectionMatrix();
+  }, [localCamera, scaledCamera, size.height, size.width]);
+
+  useFrame(() => {
+    scaledCamera.position.copy(localCamera.position);
+    scaledCamera.position.multiplyScalar(SCALED_UNITS_PER_KM);
+    scaledCamera.quaternion.copy(localCamera.quaternion);
+    scaledCamera.updateMatrixWorld();
+
+    gl.autoClear = false;
+    gl.clear();
+    gl.render(scaledScene, scaledCamera);
+    gl.clearDepth();
+  });
+
+  useEffect(() => {
+    gl.autoClear = false;
+    return () => {
+      gl.autoClear = true;
+    };
+  }, [gl]);
+
+  useEffect(() => {
+    scaledCamera.position.copy(localCamera.position).multiplyScalar(SCALED_UNITS_PER_KM);
+    scaledCamera.quaternion.copy(localCamera.quaternion);
+    scaledCamera.updateProjectionMatrix();
+    scaledCamera.updateMatrixWorld();
+  }, [localCamera, scaledCamera]);
+
+  return (
+    <>
+      {createPortal(scaled, scaledScene)}
+      {createPortal(local, localScene)}
+      {localEffects ? (
+        <EffectComposer
+          scene={localScene}
+          camera={localCamera as THREE.PerspectiveCamera}
+          renderPriority={1}
+          {...composerProps}
+        >
+          {localEffects}
+        </EffectComposer>
+      ) : null}
+    </>
+  );
+};
+
+export default SpaceRenderer;

--- a/src/sim/units.ts
+++ b/src/sim/units.ts
@@ -1,0 +1,24 @@
+import { Vector3 } from "three";
+
+export const LOCAL_UNITS_PER_KM = 1;
+export const SCALED_UNITS_PER_KM = 1 / 1000;
+
+export type Vector3Tuple = [number, number, number];
+export type Vector3Like = Vector3 | Vector3Tuple | { x: number; y: number; z: number };
+
+export const kmToLocalUnits = (km: number) => km * LOCAL_UNITS_PER_KM;
+export const kmToScaledUnits = (km: number) => km * SCALED_UNITS_PER_KM;
+
+export const toLocalUnitsKm = <T extends Vector3>(vecKm: Vector3Like, target: T): T => {
+  return target.copy(asVector3(vecKm)).multiplyScalar(LOCAL_UNITS_PER_KM) as T;
+};
+
+export const toScaledUnitsKm = <T extends Vector3>(vecKm: Vector3Like, target: T): T => {
+  return target.copy(asVector3(vecKm)).multiplyScalar(SCALED_UNITS_PER_KM) as T;
+};
+
+export const asVector3 = <T extends Vector3>(value: Vector3Like, target: T = new Vector3() as T): T => {
+  if (value instanceof Vector3) return target.copy(value) as T;
+  if (Array.isArray(value)) return target.set(value[0], value[1], value[2]) as T;
+  return target.set(value.x, value.y, value.z) as T;
+};

--- a/src/sim/worldOrigin.ts
+++ b/src/sim/worldOrigin.ts
@@ -1,0 +1,36 @@
+import { atom, useAtomValue, useSetAtom } from "jotai";
+import { Vector3 } from "three";
+
+import { Vector3Like, Vector3Tuple, asVector3 } from "./units";
+
+export const RECENTER_THRESHOLD_KM = 150;
+
+const worldOriginAtom = atom<Vector3Tuple>([0, 0, 0]);
+const shipPositionAtom = atom<Vector3Tuple>([0, 0, 0]);
+
+const setWorldOriginAtom = atom(null, (_get, set, value: Vector3Like) => {
+  const vec = asVector3(value, new Vector3());
+  set(worldOriginAtom, [vec.x, vec.y, vec.z]);
+});
+
+const setShipPositionAtom = atom(null, (_get, set, value: Vector3Like) => {
+  const vec = asVector3(value, new Vector3());
+  set(shipPositionAtom, [vec.x, vec.y, vec.z]);
+});
+
+export const maybeRecenterAtom = atom(null, (get, set, shipPosKm: Vector3Like) => {
+  const shipVec = asVector3(shipPosKm, new Vector3());
+  const originVec = asVector3(get(worldOriginAtom), new Vector3());
+
+  if (originVec.distanceTo(shipVec) > RECENTER_THRESHOLD_KM) {
+    set(worldOriginAtom, [shipVec.x, shipVec.y, shipVec.z]);
+  }
+
+  set(setShipPositionAtom, shipPosKm);
+});
+
+export const useWorldOriginKm = () => useAtomValue(worldOriginAtom);
+export const useShipPositionKm = () => useAtomValue(shipPositionAtom);
+export const useSetWorldOriginKm = () => useSetAtom(setWorldOriginAtom);
+export const useSetShipPositionKm = () => useSetAtom(setShipPositionAtom);
+export const useMaybeRecenterOrigin = () => useSetAtom(maybeRecenterAtom);


### PR DESCRIPTION
## Summary
- add simulation unit helpers and floating world origin tracking in kilometers
- introduce a dual-scene SpaceRenderer with scaled/local camera setup and SimGroup positioning utilities
- migrate scene content to kilometer-based positions for scaled planets/sun and local gameplay objects

## Testing
- npm run build *(fails: unable to fetch Google Orbitron font in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6945275cd2088324ae317dfb229d4758)