### PR TITLE
Adjust update priority to eliminate planet recenter hitch

### DIFF
--- a/src/components/Asteroids/AsteroidField.tsx
+++ b/src/components/Asteroids/AsteroidField.tsx
@@ -2,8 +2,9 @@ import { memo, useMemo } from "react";
 import { Asteroid01, Instances } from "../models/asteroids/01/Asteroid01";
 import { Euler, Vector3 } from "three";
 import random from "@/helpers/random";
+import SimGroup from "../space/SimGroup";
 
-const fieldPosition = new Vector3(0, 0, 400);
+const fieldPositionKm: readonly [number, number, number] = [0, 0, 400];
 
 const AsteroidField = () => {
   const rng = random(12344);
@@ -27,22 +28,25 @@ const AsteroidField = () => {
   }, []);
 
   return (
-    <Instances position={fieldPosition} frustumCulled={false}>
-      {positions.map((pos, i) => {
-        return (
-          <Asteroid01
-            key={i}
-            position={
-              new Vector3(pos[0] * scale, pos[1] * scale, pos[2] * scale)
-            }
-            scale={rng.nextFloat() * 10}
-            rotation={
-              new Euler(rng.nextFloat(), rng.nextFloat(), rng.nextFloat())
-            }
-          />
-        );
-      })}
-    </Instances>
+    <SimGroup space="local" positionKm={fieldPositionKm}>
+      <Instances position={[0, 0, 0]} frustumCulled={false}>
+        {positions.map((pos, i) => {
+          return (
+            <Asteroid01
+              key={i}
+              position={
+                new Vector3(pos[0] * scale, pos[1] * scale, pos[2] * scale)
+              }
+              // TODO: align asset scale with canonical kilometers.
+              scale={rng.nextFloat() * 10}
+              rotation={
+                new Euler(rng.nextFloat(), rng.nextFloat(), rng.nextFloat())
+              }
+            />
+          );
+        })}
+      </Instances>
+    </SimGroup>
   );
 };
 

--- a/src/components/Planet/Planet.tsx
+++ b/src/components/Planet/Planet.tsx
@@ -4,23 +4,29 @@ import { memo, useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import { useTexture } from "@react-three/drei";
 import * as THREE from "three";
-import { AdditiveBlending, BackSide, FrontSide, Group, Mesh } from "three";
+import { AdditiveBlending, FrontSide, Group, Mesh } from "three";
+import SimGroup from "../space/SimGroup";
+import { kmToScaledUnits, toScaledUnitsKm } from "@/sim/units";
+import { useWorldOrigin } from "@/sim/worldOrigin";
+import { STAR_POSITION_KM } from "../Star/Star";
 
-const PLANET_OFFSET = new THREE.Vector3(10, 0, -10);
 const PLANET_ROTATION = new THREE.Euler(
   1.1 * Math.PI,
   1.8 * Math.PI,
   0.8 * Math.PI
 );
-const PLANET_RADIUS = 6.37;
-
-// matches your Star.tsx convention
-const SUN_OFFSET_FROM_CAMERA = new THREE.Vector3(8000, 0, 19000);
+const DEFAULT_PLANET_POSITION_KM: readonly [number, number, number] = [
+  10_000,
+  0,
+  -10_000,
+];
+const DEFAULT_PLANET_RADIUS_KM = 6371;
+const DEFAULT_SUN_POSITION_KM = STAR_POSITION_KM;
 
 // Eclipse disabled by default (moon far away)
-const DEFAULT_MOON_OFFSET_FROM_CAMERA = new THREE.Vector3(1e9, 0, 0);
-const DEFAULT_MOON_RADIUS = 1.0;
-const DEFAULT_SUN_RADIUS = 695700;
+const DEFAULT_MOON_POSITION_KM: readonly [number, number, number] = [1e9, 0, 0];
+const DEFAULT_MOON_RADIUS_KM = 1737;
+const DEFAULT_SUN_RADIUS_KM = 696_340;
 
 const earthVertexShader = /* glsl */ `
   varying vec2 vUv;
@@ -242,12 +248,12 @@ const fresnelFragmentShader = /* glsl */ `
 `;
 
 type PlanetProps = {
-  planetOffset?: THREE.Vector3;
-  sunOffsetFromCamera?: THREE.Vector3;
-  moonOffsetFromCamera?: THREE.Vector3;
-  moonRadius?: number;
-  sunRadius?: number;
-  radius?: number;
+  positionKm?: readonly [number, number, number];
+  sunPositionKm?: readonly [number, number, number];
+  moonPositionKm?: readonly [number, number, number];
+  moonRadiusKm?: number;
+  sunRadiusKm?: number;
+  radiusKm?: number;
 };
 
 function setTextureColorSpace(
@@ -267,20 +273,23 @@ function setTextureColorSpace(
 }
 
 function Planet({
-  planetOffset = PLANET_OFFSET,
-  sunOffsetFromCamera = SUN_OFFSET_FROM_CAMERA,
-  moonOffsetFromCamera = DEFAULT_MOON_OFFSET_FROM_CAMERA,
-  moonRadius = DEFAULT_MOON_RADIUS,
-  sunRadius = DEFAULT_SUN_RADIUS,
-  radius = PLANET_RADIUS,
+  positionKm = DEFAULT_PLANET_POSITION_KM,
+  sunPositionKm = DEFAULT_SUN_POSITION_KM,
+  moonPositionKm = DEFAULT_MOON_POSITION_KM,
+  moonRadiusKm = DEFAULT_MOON_RADIUS_KM,
+  sunRadiusKm = DEFAULT_SUN_RADIUS_KM,
+  radiusKm = DEFAULT_PLANET_RADIUS_KM,
 }: PlanetProps) {
+  const worldOrigin = useWorldOrigin();
   const groupRef = useRef<Group>(null!);
 
+  const scaledRadius = useMemo(() => kmToScaledUnits(radiusKm), [radiusKm]);
+
   const sphereGeo = useMemo(() => {
-    const g = new THREE.SphereGeometry(radius, 64, 64);
+    const g = new THREE.SphereGeometry(scaledRadius, 64, 64);
     g.computeTangents();
     return g;
-  }, [radius]);
+  }, [scaledRadius]);
 
   const tex = useTexture({
     day: "/textures/earth_day.webp",
@@ -289,6 +298,19 @@ function Planet({
     spec: "/textures/earth_specular.webp",
     clouds: "/textures/earth_clouds.webp",
   }) as Record<string, THREE.Texture>;
+
+  const moonRadiusScaled = useMemo(
+    () => kmToScaledUnits(moonRadiusKm),
+    [moonRadiusKm]
+  );
+  const sunRadiusScaled = useMemo(() => kmToScaledUnits(sunRadiusKm), [sunRadiusKm]);
+
+  const sunScaled = useMemo(() => new THREE.Vector3(), []);
+  const moonScaled = useMemo(() => new THREE.Vector3(), []);
+  const earthScaled = useMemo(() => new THREE.Vector3(), []);
+  const sunRelative = useMemo(() => new THREE.Vector3(), []);
+  const moonRelative = useMemo(() => new THREE.Vector3(), []);
+  const relativeKm = useMemo(() => new THREE.Vector3(), []);
 
   useMemo(() => {
     // Color textures
@@ -323,15 +345,15 @@ function Planet({
         uNormalPower: { value: 0.6 },
 
         uMoonPos: { value: new THREE.Vector3(1e9, 0, 0) },
-        uMoonRadius: { value: moonRadius },
-        uSunRadius: { value: sunRadius },
+        uMoonRadius: { value: moonRadiusScaled },
+        uSunRadius: { value: sunRadiusScaled },
 
         uNightBoost: { value: 0.5 }, // tweak 1.0–3.0
         uCloudOpacity: { value: 0.65 }, // tweak 0.2–0.9
       },
       side: FrontSide,
     });
-  }, [tex, moonRadius, sunRadius]);
+  }, [moonRadiusScaled, sunRadiusScaled, tex]);
 
   const atmosphereMat = useMemo(() => {
     return new THREE.ShaderMaterial({
@@ -362,33 +384,40 @@ function Planet({
     });
   }, []);
 
-  useFrame(({ camera }) => {
+  // Run after SimGroup has updated this frame so uniforms reflect the final
+  // scaled position post-recenter.
+  useFrame(() => {
     if (!groupRef.current) return;
 
-    // Move planet with camera to avoid unhandled collision issues
-    groupRef.current.position.copy(camera.position).add(planetOffset);
+    earthScaled.copy(groupRef.current.position);
 
-    const earthWorld = groupRef.current.position.clone();
+    relativeKm.set(sunPositionKm[0], sunPositionKm[1], sunPositionKm[2]);
+    relativeKm.sub(worldOrigin.worldOriginKm);
+    toScaledUnitsKm(relativeKm, sunScaled);
 
-    const sunWorld = camera.position.clone().add(sunOffsetFromCamera);
-    const moonWorld = camera.position.clone().add(moonOffsetFromCamera);
+    relativeKm.set(moonPositionKm[0], moonPositionKm[1], moonPositionKm[2]);
+    relativeKm.sub(worldOrigin.worldOriginKm);
+    toScaledUnitsKm(relativeKm, moonScaled);
 
-    const sunRel = sunWorld.sub(earthWorld);
+    sunRelative.copy(sunScaled).sub(earthScaled);
+    moonRelative.copy(moonScaled);
 
-    earthMat.uniforms.uEarthPos.value.copy(groupRef.current.position);
-    earthMat.uniforms.uSunRel.value.copy(sunRel);
-    earthMat.uniforms.uMoonPos.value.copy(moonWorld);
+    earthMat.uniforms.uEarthPos.value.copy(earthScaled);
+    earthMat.uniforms.uSunRel.value.copy(sunRelative);
+    earthMat.uniforms.uMoonPos.value.copy(moonRelative);
 
-    atmosphereMat.uniforms.uSunRel.value.copy(sunRel);
-    fresnelMat.uniforms.uSunRel.value.copy(sunRel);
-  });
+    atmosphereMat.uniforms.uSunRel.value.copy(sunRelative);
+    fresnelMat.uniforms.uSunRel.value.copy(sunRelative);
+  }, 2);
 
   return (
-    <group ref={groupRef} rotation={PLANET_ROTATION}>
-      <mesh geometry={sphereGeo} material={earthMat} />
-      <mesh geometry={sphereGeo} material={atmosphereMat} scale={1.03} />
-      <mesh geometry={sphereGeo} material={fresnelMat} scale={1.002} />
-    </group>
+    <SimGroup space="scaled" positionKm={positionKm}>
+      <group ref={groupRef} rotation={PLANET_ROTATION}>
+        <mesh geometry={sphereGeo} material={earthMat} />
+        <mesh geometry={sphereGeo} material={atmosphereMat} scale={1.03} />
+        <mesh geometry={sphereGeo} material={fresnelMat} scale={1.002} />
+      </group>
+    </SimGroup>
   );
 }
 

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -19,6 +19,9 @@ import StarsComponent from "../Stars/StarsComponent";
 import { memo } from "react";
 import Anchor from "./Anchor";
 import { HalfFloatType, NoToneMapping } from "three";
+import SpaceRenderer from "../space/SpaceRenderer";
+import { WorldOriginProvider } from "@/sim/worldOrigin";
+import SunLight from "../Star/SunLight";
 
 const Scene = () => {
   const settings = useAtomValue(settingsAtom);
@@ -29,52 +32,65 @@ const Scene = () => {
       : false;
 
   return (
-    <Canvas
-      style={{ background: "black" }}
-      camera={{ far: 200_000 }}
-      frameloop="always"
-      dpr={[0.5, 1.5]}
-      gl={{
-        alpha: false,
-        premultipliedAlpha: false,
-        antialias: true,
-        powerPreference: "high-performance",
-        toneMapping: NoToneMapping,
-        logarithmicDepthBuffer: true,
-      }}
-    >
-      {settings.fps ? isSafari ? <Stats /> : <StatsGl /> : <></>}
-      <EffectComposer
-        enableNormalPass={false}
-        frameBufferType={HalfFloatType}
-        multisampling={8}
+    <WorldOriginProvider>
+      <Canvas
+        style={{ background: "black" }}
+        camera={{ near: 0.01, far: 20_000 }}
+        frameloop="always"
+        dpr={[0.5, 1.5]}
+        gl={{
+          alpha: false,
+          premultipliedAlpha: false,
+          antialias: true,
+          powerPreference: "high-performance",
+          toneMapping: NoToneMapping,
+          logarithmicDepthBuffer: true,
+        }}
       >
-        {settings.bloom ? (
-          <Bloom
-            intensity={0.02}
-            luminanceThreshold={1}
-            kernelSize={KernelSize.VERY_SMALL}
-          />
-        ) : (
-          <></>
-        )}
-        {settings.toneMapping ? (
-          <ToneMapping mode={ToneMappingMode.ACES_FILMIC} />
-        ) : (
-          <></>
-        )}
-        <SMAA />
-      </EffectComposer>
-      <ambientLight intensity={0.5} />
-      <SpaceShip />
-      <StarsComponent />
-      <AsteroidField />
-      <Planet />
-      <Star bloom={settings.bloom} />
-      <AdaptiveDpr pixelated />
-      <AdaptiveEvents />
-      <Anchor />
-    </Canvas>
+        {settings.fps ? isSafari ? <Stats /> : <StatsGl /> : <></>}
+        <EffectComposer
+          enableNormalPass={false}
+          frameBufferType={HalfFloatType}
+          multisampling={8}
+        >
+          {settings.bloom ? (
+            <Bloom
+              intensity={0.02}
+              luminanceThreshold={1}
+              kernelSize={KernelSize.VERY_SMALL}
+            />
+          ) : (
+            <></>
+          )}
+          {settings.toneMapping ? (
+            <ToneMapping mode={ToneMappingMode.ACES_FILMIC} />
+          ) : (
+            <></>
+          )}
+          <SMAA />
+        </EffectComposer>
+        <SpaceRenderer
+          scaled={
+            <>
+              <StarsComponent />
+              <Planet />
+              <Star bloom={settings.bloom} />
+            </>
+          }
+          local={
+            <>
+              <ambientLight intensity={0.5} />
+              <SunLight />
+              <SpaceShip />
+              <AsteroidField />
+            </>
+          }
+        />
+        <AdaptiveDpr pixelated />
+        <AdaptiveEvents />
+        <Anchor />
+      </Canvas>
+    </WorldOriginProvider>
   );
 };
 

--- a/src/components/Spaceship.tsx
+++ b/src/components/Spaceship.tsx
@@ -6,9 +6,9 @@ import { ShipOne } from "./models/ships/ShipOne";
 import { lerp } from "three/src/math/MathUtils.js";
 import { useAtomValue, useSetAtom } from "jotai";
 import { hudInfoAtom, movementAtom } from "@/store/store";
+import { useWorldOrigin } from "@/sim/worldOrigin";
 
 const quaternion = new Quaternion();
-const zeroVector = new Vector3(0, 0, 0);
 const xAxis = new Vector3(1, 0, 0);
 const yAxis = new Vector3(0, 1, 0);
 const direction = new Vector3(0, 0, 1); // This is the forward direction in the spaceship's local space
@@ -26,16 +26,18 @@ const hudUpdateInterval = 0.25;
 const SpaceShip = () => {
   const movement = useAtomValue(movementAtom);
   const setHudInfo = useSetAtom(hudInfoAtom);
+  const worldOrigin = useWorldOrigin();
   const shipRef = useRef<Mesh>(null!);
   const modelRef = useRef<Mesh>(null!);
-  const velocity = useRef(zeroVector);
+  const shipSimPos = useRef(new Vector3());
+  const velocity = useRef(new Vector3());
 
   const movementYaw = useRef(0); // Current roll
   const movementPitch = useRef(0); // Current yaw
   const visualRoll = useRef(0); // Current visual roll
   const visualPitch = useRef(0); // Current visual pitch
   const currentSpeed = useRef(0);
-  const oldPosition = useRef(zeroVector);
+  const oldPosition = useRef(new Vector3());
 
   useFrame(({ camera }, delta) => {
     if (shipRef.current && modelRef.current) {
@@ -100,22 +102,28 @@ const SpaceShip = () => {
       // Smoothly transition currentSpeed towards movement.speed
       currentSpeed.current = lerp(currentSpeed.current, movement.speed, 0.01);
       // Set velocity to direction multiplied by speed
-      velocity.current = direction.multiplyScalar(
-        shipSpeed * currentSpeed.current * delta
-      );
+      velocity.current
+        .copy(direction)
+        .multiplyScalar(shipSpeed * currentSpeed.current * delta);
 
-      // Update spaceship position based on velocity and delta time
-      shipRef.current.position.add(velocity.current);
+      // Update spaceship simulation position based on velocity and delta time
+      shipSimPos.current.add(velocity.current);
+      worldOrigin.setShipPosKm(shipSimPos.current);
+      worldOrigin.maybeRecenter(shipSimPos.current);
+
+      shipRef.current.position
+        .copy(shipSimPos.current)
+        .sub(worldOrigin.worldOriginKm);
 
       timeAccumulator += delta;
       if (timeAccumulator > hudUpdateInterval) {
         setHudInfo({
           speed:
-            shipRef.current.position.distanceTo(oldPosition.current) /
+            shipSimPos.current.distanceTo(oldPosition.current) /
             hudUpdateInterval,
         });
         timeAccumulator = 0;
-        oldPosition.current.copy(shipRef.current.position);
+        oldPosition.current.copy(shipSimPos.current);
       }
 
       // Calculate the camera's position

--- a/src/components/Star/Star.tsx
+++ b/src/components/Star/Star.tsx
@@ -1,37 +1,34 @@
 /* eslint-disable jsx-a11y/alt-text */
 import { Billboard, Image, Sphere } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
 import { useRef } from "react";
-import { FrontSide, Mesh, Vector3 } from "three";
-
-const position = new Vector3(65_000, 0, 130_000);
+import { FrontSide, Mesh } from "three";
+import SimGroup from "../space/SimGroup";
+import { kmToScaledUnits } from "@/sim/units";
 
 type StarProps = {
   bloom: boolean;
 };
 
-const RADIUS = 696.34;
+export const STAR_POSITION_KM: readonly [number, number, number] = [
+  65_000_000,
+  0,
+  130_000_000,
+];
+const RADIUS = kmToScaledUnits(696_340);
 
 const Star = ({ bloom }: StarProps) => {
   const star = useRef<Mesh>(null!);
 
-  // move star with camera to avoid unhandled colission issues
-  useFrame(({ camera }) => {
-    if (star.current) {
-      star.current.position.copy(camera.position).add(position);
-    }
-  });
-
   return (
-    <>
+    <SimGroup space="scaled" positionKm={STAR_POSITION_KM}>
       <directionalLight // Star
-        position={position}
+        position={[0, 0, 0]}
         intensity={10}
         color="white"
         castShadow
         scale={RADIUS}
       />
-      <mesh ref={star} position={position}>
+      <mesh ref={star}>
         {!bloom && (
           <Billboard>
             <Image url="/assets/star.png" scale={2048} transparent />
@@ -46,7 +43,7 @@ const Star = ({ bloom }: StarProps) => {
           />
         </Sphere>
       </mesh>
-    </>
+    </SimGroup>
   );
 };
 

--- a/src/components/Star/SunLight.tsx
+++ b/src/components/Star/SunLight.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useFrame } from "@react-three/fiber";
+import { useMemo, useRef } from "react";
+import { DirectionalLight, Object3D, Vector3 } from "three";
+import { useWorldOrigin } from "@/sim/worldOrigin";
+import { STAR_POSITION_KM } from "./Star";
+
+type SunLightProps = {
+  sunPositionKm?: readonly [number, number, number];
+  intensity?: number;
+  color?: string | number;
+};
+
+const MAX_LOCAL_LIGHT_DISTANCE_KM = 10_000;
+
+const SunLight = ({
+  sunPositionKm = STAR_POSITION_KM,
+  intensity = 10,
+  color = "white",
+}: SunLightProps) => {
+  const worldOrigin = useWorldOrigin();
+  const lightRef = useRef<DirectionalLight>(null!);
+  const target = useMemo(() => new Object3D(), []);
+  const relative = useMemo(() => new Vector3(), []);
+  const direction = useMemo(() => new Vector3(), []);
+
+  useFrame(() => {
+    relative.set(sunPositionKm[0], sunPositionKm[1], sunPositionKm[2]);
+    relative.sub(worldOrigin.worldOriginKm);
+
+    if (!relative.lengthSq()) return;
+
+    direction
+      .copy(relative)
+      .normalize()
+      .multiplyScalar(Math.min(relative.length(), MAX_LOCAL_LIGHT_DISTANCE_KM));
+
+    if (lightRef.current) {
+      lightRef.current.position.copy(direction);
+      target.position.set(0, 0, 0);
+      target.updateMatrixWorld();
+    }
+  });
+
+  return (
+    <>
+      <directionalLight ref={lightRef} intensity={intensity} color={color} target={target} />
+      <primitive object={target} />
+    </>
+  );
+};
+
+export default SunLight;

--- a/src/components/Stars/StarsComponent.tsx
+++ b/src/components/Stars/StarsComponent.tsx
@@ -1,21 +1,27 @@
 import { Stars } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import {
   Points,
   BufferGeometry,
   NormalBufferAttributes,
   Material,
+  Vector3,
 } from "three";
+import { SCALED_UNITS_PER_KM } from "@/sim/units";
 
 const StarsComponent = () => {
   const stars = useRef<
     Points<BufferGeometry<NormalBufferAttributes>, Material | Material[]>
   >(null!);
+  const scaledPosition = useMemo(() => new Vector3(), []);
 
   useFrame(({ camera }) => {
     if (stars.current) {
-      stars.current.position.copy(camera.position);
+      scaledPosition
+        .copy(camera.position)
+        .multiplyScalar(SCALED_UNITS_PER_KM);
+      stars.current.position.copy(scaledPosition);
     }
   });
 

--- a/src/components/space/SimGroup.tsx
+++ b/src/components/space/SimGroup.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { ReactNode, useMemo, useRef } from "react";
+import * as THREE from "three";
+import { toLocalUnitsKm, toScaledUnitsKm } from "@/sim/units";
+import { useWorldOrigin } from "@/sim/worldOrigin";
+import { useFrame } from "@react-three/fiber";
+
+type SimGroupProps = {
+  space: "local" | "scaled";
+  positionKm: readonly [number, number, number];
+  children?: ReactNode;
+};
+
+const SimGroup = ({ space, positionKm, children }: SimGroupProps) => {
+  const groupRef = useRef<THREE.Group>(null!);
+  const worldOrigin = useWorldOrigin();
+
+  const cachedPosition = useMemo(() => new THREE.Vector3(), []);
+  const relativeKm = useMemo(() => new THREE.Vector3(), []);
+
+  // Run after simulation updates (e.g., floating-origin recenter) so we use the
+  // latest world origin within the same frame, avoiding a one-frame hitch when
+  // the origin recenters.
+  useFrame(() => {
+    relativeKm.set(positionKm[0], positionKm[1], positionKm[2]);
+    relativeKm.sub(worldOrigin.worldOriginKm);
+
+    if (space === "local") {
+      toLocalUnitsKm(relativeKm, cachedPosition);
+    } else {
+      toScaledUnitsKm(relativeKm, cachedPosition);
+    }
+
+    if (groupRef.current) {
+      groupRef.current.position.copy(cachedPosition);
+    }
+  }, 1);
+
+  return <group ref={groupRef}>{children}</group>;
+};
+
+export default SimGroup;

--- a/src/components/space/SpaceRenderer.tsx
+++ b/src/components/space/SpaceRenderer.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { ReactNode, useEffect, useMemo } from "react";
+import { createPortal, useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+import { SCALED_UNITS_PER_KM } from "@/sim/units";
+
+const LOCAL_CAMERA_NEAR = 0.01;
+const LOCAL_CAMERA_FAR = 20_000;
+const SCALED_CAMERA_NEAR = 0.001;
+const SCALED_CAMERA_FAR = 2_000_000;
+
+const tempScaledPos = new THREE.Vector3();
+
+export type SpaceRendererProps = {
+  scaled: ReactNode;
+  local: ReactNode;
+};
+
+const SpaceRenderer = ({ scaled, local }: SpaceRendererProps) => {
+  const gl = useThree((state) => state.gl);
+  const size = useThree((state) => state.size);
+  const localCamera = useThree((state) => state.camera as THREE.PerspectiveCamera);
+
+  const scaledScene = useMemo(() => new THREE.Scene(), []);
+  const localScene = useMemo(() => new THREE.Scene(), []);
+  const scaledCamera = useMemo(() => localCamera.clone(), [localCamera]);
+
+  useEffect(() => {
+    const previous = gl.autoClear;
+    gl.autoClear = false;
+    return () => {
+      gl.autoClear = previous;
+    };
+  }, [gl]);
+
+  useEffect(() => {
+    localCamera.near = LOCAL_CAMERA_NEAR;
+    localCamera.far = LOCAL_CAMERA_FAR;
+    localCamera.updateProjectionMatrix();
+  }, [localCamera]);
+
+  useEffect(() => {
+    scaledCamera.near = SCALED_CAMERA_NEAR;
+    scaledCamera.far = SCALED_CAMERA_FAR;
+    scaledCamera.fov = localCamera.fov;
+    scaledCamera.aspect = size.width / size.height;
+    scaledCamera.updateProjectionMatrix();
+  }, [localCamera.fov, scaledCamera, size.height, size.width]);
+
+  useFrame(() => {
+    tempScaledPos.copy(localCamera.position).multiplyScalar(SCALED_UNITS_PER_KM);
+    scaledCamera.position.copy(tempScaledPos);
+    scaledCamera.quaternion.copy(localCamera.quaternion);
+
+    gl.clear();
+    gl.render(scaledScene, scaledCamera);
+    gl.clearDepth();
+    gl.render(localScene, localCamera);
+  }, 1);
+
+  return (
+    <>
+      {createPortal(scaled, scaledScene)}
+      {createPortal(local, localScene)}
+    </>
+  );
+};
+
+export default SpaceRenderer;

--- a/src/sim/units.ts
+++ b/src/sim/units.ts
@@ -1,0 +1,27 @@
+import * as THREE from "three";
+
+export const LOCAL_UNITS_PER_KM = 1;
+export const SCALED_UNITS_PER_KM = 1 / 1000;
+
+export type VectorLike = { x: number; y: number; z: number };
+
+export const kmToLocalUnits = (km: number) => km * LOCAL_UNITS_PER_KM;
+export const kmToScaledUnits = (km: number) => km * SCALED_UNITS_PER_KM;
+
+export function toLocalUnitsKm<T extends THREE.Vector3>(vecKm: VectorLike, target: T) {
+  target.set(
+    kmToLocalUnits(vecKm.x),
+    kmToLocalUnits(vecKm.y),
+    kmToLocalUnits(vecKm.z)
+  );
+  return target;
+}
+
+export function toScaledUnitsKm<T extends THREE.Vector3>(vecKm: VectorLike, target: T) {
+  target.set(
+    kmToScaledUnits(vecKm.x),
+    kmToScaledUnits(vecKm.y),
+    kmToScaledUnits(vecKm.z)
+  );
+  return target;
+}

--- a/src/sim/worldOrigin.tsx
+++ b/src/sim/worldOrigin.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import * as THREE from "three";
+
+const RECENTER_THRESHOLD_KM = 150;
+
+type WorldOriginContextValue = {
+  worldOriginKm: THREE.Vector3;
+  shipPosKm: THREE.Vector3;
+  setShipPosKm: (pos: THREE.Vector3) => void;
+  setWorldOriginKm: (pos: THREE.Vector3) => void;
+  maybeRecenter: (shipPosKm: THREE.Vector3) => void;
+  recenterThresholdKm: number;
+  originVersion: number;
+};
+
+const WorldOriginContext = createContext<WorldOriginContextValue | null>(null);
+
+export const WorldOriginProvider = ({ children }: { children: React.ReactNode }) => {
+  const worldOriginRef = useRef(new THREE.Vector3());
+  const shipPosRef = useRef(new THREE.Vector3());
+  const [originVersion, setOriginVersion] = useState(0);
+
+  const setWorldOriginKm = useCallback((pos: THREE.Vector3) => {
+    worldOriginRef.current.copy(pos);
+    setOriginVersion((v) => v + 1);
+  }, []);
+
+  const setShipPosKm = useCallback((pos: THREE.Vector3) => {
+    shipPosRef.current.copy(pos);
+  }, []);
+
+  const maybeRecenter = useCallback(
+    (shipPosKm: THREE.Vector3) => {
+      if (shipPosKm.distanceTo(worldOriginRef.current) > RECENTER_THRESHOLD_KM) {
+        setWorldOriginKm(shipPosKm);
+      }
+    },
+    [setWorldOriginKm]
+  );
+
+  const value = useMemo(
+    () => ({
+      worldOriginKm: worldOriginRef.current,
+      shipPosKm: shipPosRef.current,
+      setShipPosKm,
+      setWorldOriginKm,
+      maybeRecenter,
+      recenterThresholdKm: RECENTER_THRESHOLD_KM,
+      originVersion,
+    }),
+    [maybeRecenter, setShipPosKm, setWorldOriginKm, originVersion]
+  );
+
+  return <WorldOriginContext.Provider value={value}>{children}</WorldOriginContext.Provider>;
+};
+
+export const useWorldOrigin = () => {
+  const ctx = useContext(WorldOriginContext);
+  if (!ctx) throw new Error("useWorldOrigin must be used within a WorldOriginProvider");
+  return ctx;
+};
+


### PR DESCRIPTION
## Summary
- update SimGroup frame priority to reapply positions after origin recentering within the same frame
- defer planet uniform updates until after group transforms to keep scaled-space lighting in sync

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/stellar-nomad/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6945275cd2088324ae317dfb229d4758)