### PR TITLE
Restore postprocessing with dual-scene renderer

### DIFF
--- a/src/components/Asteroids/AsteroidField.tsx
+++ b/src/components/Asteroids/AsteroidField.tsx
@@ -4,7 +4,7 @@ import { Euler, Vector3 } from "three";
 import random from "@/helpers/random";
 import SimGroup from "../space/SimGroup";
 
-const fieldPositionKm: readonly [number, number, number] = [0, 0, 0];
+const fieldPositionKm: [number, number, number] = [0, 0, 0];
 
 const AsteroidField = () => {
   const rng = random(12344);
@@ -34,14 +34,10 @@ const AsteroidField = () => {
           return (
             <Asteroid01
               key={i}
-              position={
-                new Vector3(pos[0] * scale, pos[1] * scale, pos[2] * scale)
-              }
+              position={[pos[0] * scale, pos[1] * scale, pos[2] * scale]}
               // TODO: align asset scale with canonical kilometers.
               scale={rng.nextFloat() * 10}
-              rotation={
-                new Euler(rng.nextFloat(), rng.nextFloat(), rng.nextFloat())
-              }
+              rotation={[rng.nextFloat(), rng.nextFloat(), rng.nextFloat()]}
             />
           );
         })}

--- a/src/components/Asteroids/AsteroidField.tsx
+++ b/src/components/Asteroids/AsteroidField.tsx
@@ -4,7 +4,7 @@ import { Euler, Vector3 } from "three";
 import random from "@/helpers/random";
 import SimGroup from "../space/SimGroup";
 
-const fieldPositionKm: readonly [number, number, number] = [0, 0, 400];
+const fieldPositionKm: readonly [number, number, number] = [0, 0, 0];
 
 const AsteroidField = () => {
   const rng = random(12344);

--- a/src/components/Asteroids/AsteroidField.tsx
+++ b/src/components/Asteroids/AsteroidField.tsx
@@ -2,8 +2,9 @@ import { memo, useMemo } from "react";
 import { Asteroid01, Instances } from "../models/asteroids/01/Asteroid01";
 import { Euler, Vector3 } from "three";
 import random from "@/helpers/random";
+import SimGroup from "../space/SimGroup";
 
-const fieldPosition = new Vector3(0, 0, 400);
+const fieldPositionKm: readonly [number, number, number] = [0, 0, 400];
 
 const AsteroidField = () => {
   const rng = random(12344);
@@ -27,22 +28,25 @@ const AsteroidField = () => {
   }, []);
 
   return (
-    <Instances position={fieldPosition} frustumCulled={false}>
-      {positions.map((pos, i) => {
-        return (
-          <Asteroid01
-            key={i}
-            position={
-              new Vector3(pos[0] * scale, pos[1] * scale, pos[2] * scale)
-            }
-            scale={rng.nextFloat() * 10}
-            rotation={
-              new Euler(rng.nextFloat(), rng.nextFloat(), rng.nextFloat())
-            }
-          />
-        );
-      })}
-    </Instances>
+    <SimGroup space="local" positionKm={fieldPositionKm}>
+      <Instances position={[0, 0, 0]} frustumCulled={false}>
+        {positions.map((pos, i) => {
+          return (
+            <Asteroid01
+              key={i}
+              position={
+                new Vector3(pos[0] * scale, pos[1] * scale, pos[2] * scale)
+              }
+              // TODO: align asset scale with canonical kilometers.
+              scale={rng.nextFloat() * 10}
+              rotation={
+                new Euler(rng.nextFloat(), rng.nextFloat(), rng.nextFloat())
+              }
+            />
+          );
+        })}
+      </Instances>
+    </SimGroup>
   );
 };
 

--- a/src/components/Planet/Planet.tsx
+++ b/src/components/Planet/Planet.tsx
@@ -15,14 +15,14 @@ const PLANET_ROTATION = new THREE.Euler(
   1.8 * Math.PI,
   0.8 * Math.PI
 );
-const DEFAULT_PLANET_POSITION_KM: readonly [number, number, number] = [
+const DEFAULT_PLANET_POSITION_KM: [number, number, number] = [
   5_000, 0, -15_000,
 ];
 const DEFAULT_PLANET_RADIUS_KM = 6371;
 const DEFAULT_SUN_POSITION_KM = STAR_POSITION_KM;
 
 // Eclipse disabled by default (moon far away)
-const DEFAULT_MOON_POSITION_KM: readonly [number, number, number] = [1e9, 0, 0];
+const DEFAULT_MOON_POSITION_KM: [number, number, number] = [1e9, 0, 0];
 const DEFAULT_MOON_RADIUS_KM = 1.737;
 const DEFAULT_SUN_RADIUS_KM = 696.34;
 
@@ -253,9 +253,9 @@ const fresnelFragmentShader = /* glsl */ `
 `;
 
 type PlanetProps = {
-  positionKm?: readonly [number, number, number];
-  sunPositionKm?: readonly [number, number, number];
-  moonPositionKm?: readonly [number, number, number];
+  positionKm?: [number, number, number];
+  sunPositionKm?: [number, number, number];
+  moonPositionKm?: [number, number, number];
   moonRadiusKm?: number;
   sunRadiusKm?: number;
   radiusKm?: number;

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -3,14 +3,7 @@
 import { settingsAtom } from "@/store/store";
 import { Stats, StatsGl, AdaptiveDpr, AdaptiveEvents } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
-import {
-  Bloom,
-  EffectComposer,
-  SMAA,
-  ToneMapping,
-} from "@react-three/postprocessing";
 import { useAtomValue } from "jotai";
-import { KernelSize, ToneMappingMode } from "postprocessing";
 import AsteroidField from "../Asteroids/AsteroidField";
 import Planet from "../Planet/Planet";
 import SpaceShip from "../Spaceship";
@@ -18,7 +11,10 @@ import Star from "../Star/Star";
 import StarsComponent from "../Stars/StarsComponent";
 import { memo } from "react";
 import Anchor from "./Anchor";
-import { HalfFloatType, NoToneMapping } from "three";
+import { NoToneMapping } from "three";
+import SpaceRenderer from "../space/SpaceRenderer";
+import { WorldOriginProvider } from "@/sim/worldOrigin";
+import SunLight from "../Star/SunLight";
 
 const Scene = () => {
   const settings = useAtomValue(settingsAtom);
@@ -29,52 +25,48 @@ const Scene = () => {
       : false;
 
   return (
-    <Canvas
-      style={{ background: "black" }}
-      camera={{ far: 200_000 }}
-      frameloop="always"
-      dpr={[0.5, 1.5]}
-      gl={{
-        alpha: false,
-        premultipliedAlpha: false,
-        antialias: true,
-        powerPreference: "high-performance",
-        toneMapping: NoToneMapping,
-        logarithmicDepthBuffer: true,
-      }}
-    >
-      {settings.fps ? isSafari ? <Stats /> : <StatsGl /> : <></>}
-      <EffectComposer
-        enableNormalPass={false}
-        frameBufferType={HalfFloatType}
-        multisampling={8}
+    <WorldOriginProvider>
+      <Canvas
+        style={{ background: "black" }}
+        camera={{ near: 0.01, far: 20_000 }}
+        frameloop="always"
+        dpr={[0.5, 1.5]}
+        gl={{
+          alpha: false,
+          premultipliedAlpha: false,
+          antialias: true,
+          powerPreference: "high-performance",
+          toneMapping: NoToneMapping,
+          logarithmicDepthBuffer: true,
+        }}
       >
-        {settings.bloom ? (
-          <Bloom
-            intensity={0.02}
-            luminanceThreshold={1}
-            kernelSize={KernelSize.VERY_SMALL}
-          />
-        ) : (
-          <></>
-        )}
-        {settings.toneMapping ? (
-          <ToneMapping mode={ToneMappingMode.ACES_FILMIC} />
-        ) : (
-          <></>
-        )}
-        <SMAA />
-      </EffectComposer>
-      <ambientLight intensity={0.5} />
-      <SpaceShip />
-      <StarsComponent />
-      <AsteroidField />
-      <Planet />
-      <Star bloom={settings.bloom} />
-      <AdaptiveDpr pixelated />
-      <AdaptiveEvents />
-      <Anchor />
-    </Canvas>
+        {settings.fps ? isSafari ? <Stats /> : <StatsGl /> : <></>}
+        <SpaceRenderer
+          postprocess={{
+            bloom: settings.bloom,
+            toneMapping: settings.toneMapping,
+          }}
+          scaled={
+            <>
+              <StarsComponent />
+              <Planet />
+              <Star bloom={settings.bloom} />
+            </>
+          }
+          local={
+            <>
+              <ambientLight intensity={0.5} />
+              <SunLight />
+              <SpaceShip />
+              <AsteroidField />
+            </>
+          }
+        />
+        <AdaptiveDpr pixelated />
+        <AdaptiveEvents />
+        <Anchor />
+      </Canvas>
+    </WorldOriginProvider>
   );
 };
 

--- a/src/components/Scene/Scene.tsx
+++ b/src/components/Scene/Scene.tsx
@@ -42,10 +42,6 @@ const Scene = () => {
       >
         {settings.fps ? isSafari ? <Stats /> : <StatsGl /> : <></>}
         <SpaceRenderer
-          postprocess={{
-            bloom: settings.bloom,
-            toneMapping: settings.toneMapping,
-          }}
           scaled={
             <>
               <StarsComponent />

--- a/src/components/Spaceship.tsx
+++ b/src/components/Spaceship.tsx
@@ -125,7 +125,8 @@ const SpaceShip = () => {
       timeAccumulator += delta;
       if (timeAccumulator > hudUpdateInterval) {
         const speedKmPerSec =
-          shipSimPos.current.distanceTo(oldPosition.current) / hudUpdateInterval;
+          shipSimPos.current.distanceTo(oldPosition.current) /
+          hudUpdateInterval;
 
         setHudInfo({
           // HUD expects meters/second; simulation runs in kilometers.
@@ -156,9 +157,7 @@ const SpaceShip = () => {
 
   return (
     <mesh ref={shipRef}>
-      <mesh ref={modelRef}>
-        <ShipOne />
-      </mesh>
+      <ShipOne ref={modelRef} />
     </mesh>
   );
 };

--- a/src/components/Spaceship.tsx
+++ b/src/components/Spaceship.tsx
@@ -6,9 +6,10 @@ import { ShipOne } from "./models/ships/ShipOne";
 import { lerp } from "three/src/math/MathUtils.js";
 import { useAtomValue, useSetAtom } from "jotai";
 import { hudInfoAtom, movementAtom } from "@/store/store";
+import { useWorldOrigin } from "@/sim/worldOrigin";
+import { toLocalUnitsKm } from "@/sim/units";
 
 const quaternion = new Quaternion();
-const zeroVector = new Vector3(0, 0, 0);
 const xAxis = new Vector3(1, 0, 0);
 const yAxis = new Vector3(0, 1, 0);
 const direction = new Vector3(0, 0, 1); // This is the forward direction in the spaceship's local space
@@ -19,23 +20,29 @@ rotationQuaternion.setFromAxisAngle(yAxis, Math.PI);
 
 const shipHandling = 1.5;
 const maxRotationSpeed = shipHandling / 2;
-const shipSpeed = 100;
+// Simulation space is kilometers, but ship speeds are authored in meters/second
+// to align with the HUD and player expectation. Convert to km/s for integration.
+const SHIP_MAX_SPEED_MPS = 100;
+const SHIP_MAX_SPEED_KMPS = SHIP_MAX_SPEED_MPS / 1000;
 let timeAccumulator = 0;
 const hudUpdateInterval = 0.25;
 
 const SpaceShip = () => {
   const movement = useAtomValue(movementAtom);
   const setHudInfo = useSetAtom(hudInfoAtom);
+  const worldOrigin = useWorldOrigin();
   const shipRef = useRef<Mesh>(null!);
   const modelRef = useRef<Mesh>(null!);
-  const velocity = useRef(zeroVector);
+  const shipSimPos = useRef(new Vector3());
+  const velocity = useRef(new Vector3());
+  const localRelative = useRef(new Vector3());
 
   const movementYaw = useRef(0); // Current roll
   const movementPitch = useRef(0); // Current yaw
   const visualRoll = useRef(0); // Current visual roll
   const visualPitch = useRef(0); // Current visual pitch
   const currentSpeed = useRef(0);
-  const oldPosition = useRef(zeroVector);
+  const oldPosition = useRef(new Vector3());
 
   useFrame(({ camera }, delta) => {
     if (shipRef.current && modelRef.current) {
@@ -100,22 +107,32 @@ const SpaceShip = () => {
       // Smoothly transition currentSpeed towards movement.speed
       currentSpeed.current = lerp(currentSpeed.current, movement.speed, 0.01);
       // Set velocity to direction multiplied by speed
-      velocity.current = direction.multiplyScalar(
-        shipSpeed * currentSpeed.current * delta
-      );
+      velocity.current
+        .copy(direction)
+        .multiplyScalar(SHIP_MAX_SPEED_KMPS * currentSpeed.current * delta);
 
-      // Update spaceship position based on velocity and delta time
-      shipRef.current.position.add(velocity.current);
+      // Update spaceship simulation position based on velocity and delta time
+      shipSimPos.current.add(velocity.current);
+      worldOrigin.setShipPosKm(shipSimPos.current);
+      worldOrigin.maybeRecenter(shipSimPos.current);
+
+      localRelative.current
+        .copy(shipSimPos.current)
+        .sub(worldOrigin.worldOriginKm);
+
+      toLocalUnitsKm(localRelative.current, shipRef.current.position);
 
       timeAccumulator += delta;
       if (timeAccumulator > hudUpdateInterval) {
+        const speedKmPerSec =
+          shipSimPos.current.distanceTo(oldPosition.current) / hudUpdateInterval;
+
         setHudInfo({
-          speed:
-            shipRef.current.position.distanceTo(oldPosition.current) /
-            hudUpdateInterval,
+          // HUD expects meters/second; simulation runs in kilometers.
+          speed: speedKmPerSec * 1000,
         });
         timeAccumulator = 0;
-        oldPosition.current.copy(shipRef.current.position);
+        oldPosition.current.copy(shipSimPos.current);
       }
 
       // Calculate the camera's position

--- a/src/components/Star/Star.tsx
+++ b/src/components/Star/Star.tsx
@@ -1,37 +1,34 @@
 /* eslint-disable jsx-a11y/alt-text */
 import { Billboard, Image, Sphere } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
 import { useRef } from "react";
-import { FrontSide, Mesh, Vector3 } from "three";
-
-const position = new Vector3(65_000, 0, 130_000);
+import { FrontSide, Mesh } from "three";
+import SimGroup from "../space/SimGroup";
+import { kmToScaledUnits } from "@/sim/units";
 
 type StarProps = {
   bloom: boolean;
 };
 
-const RADIUS = 696.34;
+export const STAR_POSITION_KM: readonly [number, number, number] = [
+  65_000_000,
+  0,
+  130_000_000,
+];
+const RADIUS = kmToScaledUnits(696_340);
 
 const Star = ({ bloom }: StarProps) => {
   const star = useRef<Mesh>(null!);
 
-  // move star with camera to avoid unhandled colission issues
-  useFrame(({ camera }) => {
-    if (star.current) {
-      star.current.position.copy(camera.position).add(position);
-    }
-  });
-
   return (
-    <>
+    <SimGroup space="scaled" positionKm={STAR_POSITION_KM}>
       <directionalLight // Star
-        position={position}
+        position={[0, 0, 0]}
         intensity={10}
         color="white"
         castShadow
         scale={RADIUS}
       />
-      <mesh ref={star} position={position}>
+      <mesh ref={star}>
         {!bloom && (
           <Billboard>
             <Image url="/assets/star.png" scale={2048} transparent />
@@ -46,7 +43,7 @@ const Star = ({ bloom }: StarProps) => {
           />
         </Sphere>
       </mesh>
-    </>
+    </SimGroup>
   );
 };
 

--- a/src/components/Star/Star.tsx
+++ b/src/components/Star/Star.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/alt-text */
 import { Billboard, Image, Sphere } from "@react-three/drei";
 import { useRef } from "react";
-import { FrontSide, Mesh } from "three";
+import { FrontSide, Group } from "three";
 import SimGroup from "../space/SimGroup";
 import { kmToScaledUnits } from "@/sim/units";
 
@@ -9,26 +9,17 @@ type StarProps = {
   bloom: boolean;
 };
 
-export const STAR_POSITION_KM: readonly [number, number, number] = [
-  65_000_000,
-  0,
-  130_000_000,
+export const STAR_POSITION_KM: [number, number, number] = [
+  130_000_000, 0, 130_000_000,
 ];
 const RADIUS = kmToScaledUnits(696_340);
 
 const Star = ({ bloom }: StarProps) => {
-  const star = useRef<Mesh>(null!);
+  const star = useRef<Group>(null!);
 
   return (
     <SimGroup space="scaled" positionKm={STAR_POSITION_KM}>
-      <directionalLight // Star
-        position={[0, 0, 0]}
-        intensity={10}
-        color="white"
-        castShadow
-        scale={RADIUS}
-      />
-      <mesh ref={star}>
+      <group ref={star}>
         {!bloom && (
           <Billboard>
             <Image url="/assets/star.png" scale={2048} transparent />
@@ -42,7 +33,7 @@ const Star = ({ bloom }: StarProps) => {
             depthTest={true}
           />
         </Sphere>
-      </mesh>
+      </group>
     </SimGroup>
   );
 };

--- a/src/components/Star/SunLight.tsx
+++ b/src/components/Star/SunLight.tsx
@@ -1,61 +1,25 @@
 "use client";
 
-import { useFrame } from "@react-three/fiber";
-import { useMemo, useRef } from "react";
-import { DirectionalLight, Object3D, Vector3 } from "three";
-import { useWorldOrigin } from "@/sim/worldOrigin";
 import { STAR_POSITION_KM } from "./Star";
-import { kmToLocalUnits, toLocalUnitsKm } from "@/sim/units";
 
 type SunLightProps = {
-  sunPositionKm?: readonly [number, number, number];
+  sunPositionKm?: [number, number, number];
   intensity?: number;
   color?: string | number;
 };
 
-const MAX_LOCAL_LIGHT_DISTANCE_KM = 10_000;
-
 const SunLight = ({
   sunPositionKm = STAR_POSITION_KM,
-  intensity = 10,
+  intensity = 30,
   color = "white",
 }: SunLightProps) => {
-  const worldOrigin = useWorldOrigin();
-  const lightRef = useRef<DirectionalLight>(null!);
-  const target = useMemo(() => new Object3D(), []);
-  const relative = useMemo(() => new Vector3(), []);
-  const relativeLocal = useMemo(() => new Vector3(), []);
-  const direction = useMemo(() => new Vector3(), []);
-
-  useFrame(() => {
-    relative.set(sunPositionKm[0], sunPositionKm[1], sunPositionKm[2]);
-    relative.sub(worldOrigin.worldOriginKm);
-
-    if (!relative.lengthSq()) return;
-
-    toLocalUnitsKm(relative, relativeLocal);
-
-    direction
-      .copy(relativeLocal)
-      .normalize()
-      .multiplyScalar(
-        Math.min(
-          relativeLocal.length(),
-          kmToLocalUnits(MAX_LOCAL_LIGHT_DISTANCE_KM)
-        )
-      );
-
-    if (lightRef.current) {
-      lightRef.current.position.copy(direction);
-      target.position.set(0, 0, 0);
-      target.updateMatrixWorld();
-    }
-  });
-
   return (
     <>
-      <directionalLight ref={lightRef} intensity={intensity} color={color} target={target} />
-      <primitive object={target} />
+      <directionalLight
+        position={sunPositionKm}
+        intensity={intensity}
+        color={color}
+      />
     </>
   );
 };

--- a/src/components/Star/SunLight.tsx
+++ b/src/components/Star/SunLight.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useFrame } from "@react-three/fiber";
+import { useMemo, useRef } from "react";
+import { DirectionalLight, Object3D, Vector3 } from "three";
+import { useWorldOrigin } from "@/sim/worldOrigin";
+import { STAR_POSITION_KM } from "./Star";
+import { kmToLocalUnits, toLocalUnitsKm } from "@/sim/units";
+
+type SunLightProps = {
+  sunPositionKm?: readonly [number, number, number];
+  intensity?: number;
+  color?: string | number;
+};
+
+const MAX_LOCAL_LIGHT_DISTANCE_KM = 10_000;
+
+const SunLight = ({
+  sunPositionKm = STAR_POSITION_KM,
+  intensity = 10,
+  color = "white",
+}: SunLightProps) => {
+  const worldOrigin = useWorldOrigin();
+  const lightRef = useRef<DirectionalLight>(null!);
+  const target = useMemo(() => new Object3D(), []);
+  const relative = useMemo(() => new Vector3(), []);
+  const relativeLocal = useMemo(() => new Vector3(), []);
+  const direction = useMemo(() => new Vector3(), []);
+
+  useFrame(() => {
+    relative.set(sunPositionKm[0], sunPositionKm[1], sunPositionKm[2]);
+    relative.sub(worldOrigin.worldOriginKm);
+
+    if (!relative.lengthSq()) return;
+
+    toLocalUnitsKm(relative, relativeLocal);
+
+    direction
+      .copy(relativeLocal)
+      .normalize()
+      .multiplyScalar(
+        Math.min(
+          relativeLocal.length(),
+          kmToLocalUnits(MAX_LOCAL_LIGHT_DISTANCE_KM)
+        )
+      );
+
+    if (lightRef.current) {
+      lightRef.current.position.copy(direction);
+      target.position.set(0, 0, 0);
+      target.updateMatrixWorld();
+    }
+  });
+
+  return (
+    <>
+      <directionalLight ref={lightRef} intensity={intensity} color={color} target={target} />
+      <primitive object={target} />
+    </>
+  );
+};
+
+export default SunLight;

--- a/src/components/Stars/StarsComponent.tsx
+++ b/src/components/Stars/StarsComponent.tsx
@@ -1,21 +1,27 @@
 import { Stars } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import {
   Points,
   BufferGeometry,
   NormalBufferAttributes,
   Material,
+  Vector3,
 } from "three";
+import { SCALED_UNITS_PER_KM } from "@/sim/units";
 
 const StarsComponent = () => {
   const stars = useRef<
     Points<BufferGeometry<NormalBufferAttributes>, Material | Material[]>
   >(null!);
+  const scaledPosition = useMemo(() => new Vector3(), []);
 
   useFrame(({ camera }) => {
     if (stars.current) {
-      stars.current.position.copy(camera.position);
+      scaledPosition
+        .copy(camera.position)
+        .multiplyScalar(SCALED_UNITS_PER_KM);
+      stars.current.position.copy(scaledPosition);
     }
   });
 

--- a/src/components/Stars/StarsComponent.tsx
+++ b/src/components/Stars/StarsComponent.tsx
@@ -10,17 +10,16 @@ import {
 } from "three";
 import { SCALED_UNITS_PER_KM } from "@/sim/units";
 
+const scaledPosition = new Vector3();
+
 const StarsComponent = () => {
   const stars = useRef<
     Points<BufferGeometry<NormalBufferAttributes>, Material | Material[]>
   >(null!);
-  const scaledPosition = useMemo(() => new Vector3(), []);
 
   useFrame(({ camera }) => {
     if (stars.current) {
-      scaledPosition
-        .copy(camera.position)
-        .multiplyScalar(SCALED_UNITS_PER_KM);
+      scaledPosition.copy(camera.position).multiplyScalar(SCALED_UNITS_PER_KM);
       stars.current.position.copy(scaledPosition);
     }
   });

--- a/src/components/space/SimGroup.tsx
+++ b/src/components/space/SimGroup.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ReactNode, useMemo, useRef } from "react";
+import * as THREE from "three";
+import { toLocalUnitsKm, toScaledUnitsKm } from "@/sim/units";
+import { useWorldOrigin } from "@/sim/worldOrigin";
+import { useFrame } from "@react-three/fiber";
+
+type SimGroupProps = {
+  space: "local" | "scaled";
+  positionKm: readonly [number, number, number];
+  children?: ReactNode;
+};
+
+const SimGroup = ({ space, positionKm, children }: SimGroupProps) => {
+  const groupRef = useRef<THREE.Group>(null!);
+  const worldOrigin = useWorldOrigin();
+
+  const cachedPosition = useMemo(() => new THREE.Vector3(), []);
+  const relativeKm = useMemo(() => new THREE.Vector3(), []);
+
+  useFrame(() => {
+    relativeKm.set(positionKm[0], positionKm[1], positionKm[2]);
+    relativeKm.sub(worldOrigin.worldOriginKm);
+
+    if (space === "local") {
+      toLocalUnitsKm(relativeKm, cachedPosition);
+    } else {
+      toScaledUnitsKm(relativeKm, cachedPosition);
+    }
+
+    if (groupRef.current) {
+      groupRef.current.position.copy(cachedPosition);
+    }
+  });
+
+  return <group ref={groupRef}>{children}</group>;
+};
+
+export default SimGroup;

--- a/src/components/space/SimGroup.tsx
+++ b/src/components/space/SimGroup.tsx
@@ -8,16 +8,16 @@ import { useFrame } from "@react-three/fiber";
 
 type SimGroupProps = {
   space: "local" | "scaled";
-  positionKm: readonly [number, number, number];
+  positionKm: [number, number, number];
   children?: ReactNode;
 };
+
+const cachedPosition = new THREE.Vector3();
+const relativeKm = new THREE.Vector3();
 
 const SimGroup = ({ space, positionKm, children }: SimGroupProps) => {
   const groupRef = useRef<THREE.Group>(null!);
   const worldOrigin = useWorldOrigin();
-
-  const cachedPosition = useMemo(() => new THREE.Vector3(), []);
-  const relativeKm = useMemo(() => new THREE.Vector3(), []);
 
   useFrame(() => {
     relativeKm.set(positionKm[0], positionKm[1], positionKm[2]);

--- a/src/components/space/SpaceRenderer.tsx
+++ b/src/components/space/SpaceRenderer.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { ReactNode, useEffect, useMemo } from "react";
+import { createPortal, useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+import { LOCAL_TO_SCALED_FROM_LOCAL_UNITS } from "@/sim/units";
+import {
+  EffectComposer as PostProcessingComposer,
+  RenderPass,
+  EffectPass,
+  SMAAEffect,
+  BloomEffect,
+  ToneMappingEffect,
+  KernelSize,
+  ToneMappingMode,
+} from "postprocessing";
+import { HalfFloatType } from "three";
+
+const LOCAL_CAMERA_NEAR = 0.01;
+// 20,000 km expressed in local meters
+const LOCAL_CAMERA_FAR = 20_000 * 1000;
+const SCALED_CAMERA_NEAR = 0.001;
+const SCALED_CAMERA_FAR = 2_000_000;
+
+const tempScaledPos = new THREE.Vector3();
+
+export type SpaceRendererProps = {
+  scaled: ReactNode;
+  local: ReactNode;
+  postprocess?: {
+    bloom: boolean;
+    toneMapping: boolean;
+  };
+};
+
+const SpaceRenderer = ({ scaled, local, postprocess }: SpaceRendererProps) => {
+  const gl = useThree((state) => state.gl);
+  const size = useThree((state) => state.size);
+  const localCamera = useThree((state) => state.camera as THREE.PerspectiveCamera);
+
+  const scaledScene = useMemo(() => new THREE.Scene(), []);
+  const localScene = useMemo(() => new THREE.Scene(), []);
+  const scaledCamera = useMemo(() => localCamera.clone(), [localCamera]);
+  const scaledPass = useMemo(() => new RenderPass(scaledScene, scaledCamera), [scaledScene, scaledCamera]);
+  const localPass = useMemo(() => new RenderPass(localScene, localCamera), [localScene, localCamera]);
+  const composer = useMemo(() => {
+    const newComposer = new PostProcessingComposer(gl, {
+      frameBufferType: HalfFloatType,
+      multisampling: 8,
+    });
+    return newComposer;
+  }, [gl]);
+
+  useEffect(() => {
+    const previous = gl.autoClear;
+    gl.autoClear = false;
+    return () => {
+      gl.autoClear = previous;
+    };
+  }, [gl]);
+
+  useEffect(() => {
+    scaledPass.clear = true;
+    localPass.clear = false;
+    localPass.clearDepth = true;
+
+    composer.removeAllPasses();
+    composer.addPass(scaledPass);
+    composer.addPass(localPass);
+
+    const effects = [] as Array<BloomEffect | ToneMappingEffect | SMAAEffect>;
+    if (postprocess?.bloom) {
+      effects.push(
+        new BloomEffect({
+          intensity: 0.02,
+          luminanceThreshold: 1,
+          kernelSize: KernelSize.VERY_SMALL,
+        }),
+      );
+    }
+    if (postprocess?.toneMapping) {
+      effects.push(new ToneMappingEffect({ mode: ToneMappingMode.ACES_FILMIC }));
+    }
+
+    effects.push(new SMAAEffect());
+
+    if (effects.length > 0) {
+      composer.addPass(new EffectPass(localCamera, ...effects));
+    }
+
+    return () => {
+      composer.removeAllPasses();
+    };
+  }, [composer, localCamera, localPass, postprocess?.bloom, postprocess?.toneMapping, scaledPass]);
+
+  useEffect(() => {
+    localCamera.near = LOCAL_CAMERA_NEAR;
+    localCamera.far = LOCAL_CAMERA_FAR;
+    localCamera.updateProjectionMatrix();
+  }, [localCamera]);
+
+  useEffect(() => {
+    scaledCamera.near = SCALED_CAMERA_NEAR;
+    scaledCamera.far = SCALED_CAMERA_FAR;
+    scaledCamera.fov = localCamera.fov;
+    scaledCamera.aspect = size.width / size.height;
+    scaledCamera.updateProjectionMatrix();
+  }, [localCamera.fov, scaledCamera, size.height, size.width]);
+
+  useEffect(() => {
+    composer.setSize(size.width, size.height);
+  }, [composer, size.height, size.width]);
+
+  useEffect(() => () => composer.dispose(), [composer]);
+
+  useFrame(() => {
+    tempScaledPos
+      .copy(localCamera.position)
+      .multiplyScalar(LOCAL_TO_SCALED_FROM_LOCAL_UNITS);
+    scaledCamera.position.copy(tempScaledPos);
+    scaledCamera.quaternion.copy(localCamera.quaternion);
+
+    composer.render();
+  }, 1);
+
+  return (
+    <>
+      {createPortal(scaled, scaledScene)}
+      {createPortal(local, localScene)}
+    </>
+  );
+};
+
+export default SpaceRenderer;

--- a/src/sim/units.ts
+++ b/src/sim/units.ts
@@ -1,0 +1,35 @@
+import * as THREE from "three";
+
+// Local space is authored in meters (1 unit = 1 m) while the canonical
+// simulation positions are kilometers. Scaled space keeps far-field bodies
+// compact by using 1 unit = 1000 km.
+export const LOCAL_UNITS_PER_KM = 1000;
+export const SCALED_UNITS_PER_KM = 1 / 1000;
+
+// Helpful factors for translating between the two render spaces when starting
+// from local-space coordinates.
+export const LOCAL_TO_SCALED_FROM_LOCAL_UNITS =
+  SCALED_UNITS_PER_KM / LOCAL_UNITS_PER_KM;
+
+export type VectorLike = { x: number; y: number; z: number };
+
+export const kmToLocalUnits = (km: number) => km * LOCAL_UNITS_PER_KM;
+export const kmToScaledUnits = (km: number) => km * SCALED_UNITS_PER_KM;
+
+export function toLocalUnitsKm<T extends THREE.Vector3>(vecKm: VectorLike, target: T) {
+  target.set(
+    kmToLocalUnits(vecKm.x),
+    kmToLocalUnits(vecKm.y),
+    kmToLocalUnits(vecKm.z)
+  );
+  return target;
+}
+
+export function toScaledUnitsKm<T extends THREE.Vector3>(vecKm: VectorLike, target: T) {
+  target.set(
+    kmToScaledUnits(vecKm.x),
+    kmToScaledUnits(vecKm.y),
+    kmToScaledUnits(vecKm.z)
+  );
+  return target;
+}

--- a/src/sim/units.ts
+++ b/src/sim/units.ts
@@ -16,7 +16,10 @@ export type VectorLike = { x: number; y: number; z: number };
 export const kmToLocalUnits = (km: number) => km * LOCAL_UNITS_PER_KM;
 export const kmToScaledUnits = (km: number) => km * SCALED_UNITS_PER_KM;
 
-export function toLocalUnitsKm<T extends THREE.Vector3>(vecKm: VectorLike, target: T) {
+export function toLocalUnitsKm<T extends THREE.Vector3>(
+  vecKm: VectorLike,
+  target: T
+) {
   target.set(
     kmToLocalUnits(vecKm.x),
     kmToLocalUnits(vecKm.y),
@@ -25,7 +28,10 @@ export function toLocalUnitsKm<T extends THREE.Vector3>(vecKm: VectorLike, targe
   return target;
 }
 
-export function toScaledUnitsKm<T extends THREE.Vector3>(vecKm: VectorLike, target: T) {
+export function toScaledUnitsKm<T extends THREE.Vector3>(
+  vecKm: VectorLike,
+  target: T
+) {
   target.set(
     kmToScaledUnits(vecKm.x),
     kmToScaledUnits(vecKm.y),

--- a/src/sim/worldOrigin.tsx
+++ b/src/sim/worldOrigin.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useMemo, useRef } from "react";
+import * as THREE from "three";
+
+const RECENTER_THRESHOLD_KM = 10_000;
+
+type WorldOriginContextValue = {
+  worldOriginKm: THREE.Vector3;
+  shipPosKm: THREE.Vector3;
+  setShipPosKm: (pos: THREE.Vector3) => void;
+  setWorldOriginKm: (pos: THREE.Vector3) => void;
+  maybeRecenter: (shipPosKm: THREE.Vector3) => void;
+  recenterThresholdKm: number;
+};
+
+const WorldOriginContext = createContext<WorldOriginContextValue | null>(null);
+
+export const WorldOriginProvider = ({ children }: { children: React.ReactNode }) => {
+  const worldOriginRef = useRef(new THREE.Vector3());
+  const shipPosRef = useRef(new THREE.Vector3());
+
+  const setWorldOriginKm = useCallback((pos: THREE.Vector3) => {
+    worldOriginRef.current.copy(pos);
+  }, []);
+
+  const setShipPosKm = useCallback((pos: THREE.Vector3) => {
+    shipPosRef.current.copy(pos);
+  }, []);
+
+  const maybeRecenter = useCallback(
+    (shipPosKm: THREE.Vector3) => {
+      if (shipPosKm.distanceTo(worldOriginRef.current) > RECENTER_THRESHOLD_KM) {
+        setWorldOriginKm(shipPosKm);
+      }
+    },
+    [setWorldOriginKm]
+  );
+
+  const value = useMemo(
+    () => ({
+      worldOriginKm: worldOriginRef.current,
+      shipPosKm: shipPosRef.current,
+      setShipPosKm,
+      setWorldOriginKm,
+      maybeRecenter,
+      recenterThresholdKm: RECENTER_THRESHOLD_KM,
+    }),
+    [maybeRecenter, setShipPosKm, setWorldOriginKm]
+  );
+
+  return <WorldOriginContext.Provider value={value}>{children}</WorldOriginContext.Provider>;
+};
+
+export const useWorldOrigin = () => {
+  const ctx = useContext(WorldOriginContext);
+  if (!ctx) throw new Error("useWorldOrigin must be used within a WorldOriginProvider");
+  return ctx;
+};
+


### PR DESCRIPTION
## Summary
- move postprocessing into the dual-scene SpaceRenderer so scaled and local scenes share Bloom/ToneMapping/SMAA
- rebuild the composer pipeline with dedicated render passes for scaled and local scenes before applying effects
- expose postprocess toggles from the Scene to preserve existing settings controls

## Testing
- `npm run build` *(fails: unable to fetch Orbitron font from Google Fonts in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6945275cd2088324ae317dfb229d4758)